### PR TITLE
feat: Add mergeFrom directive for dictionary iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,39 @@ There may be instances where you want to create multiple files from the same tem
 ```
 This directive requires that the ``items:`` specified be an iterable List or Dictionary. The template will be merged, and an output file will be generated for each member of the list. The current processing item is exposed in context at the entry ``item``. Values from item are also used to process the output file name, so in the example above each object in the sources List has a name property which is used to create a unique file name for each output file. 
 
+#### Dictionary Iteration in mergeFor
+When the `items` path resolves to a dictionary (such as a folder of YAML files), the processor will iterate over its key-value pairs:
+- Each iteration provides an `item` with `name` (the key) and `content` (the value)
+- This allows you to generate a file for each entry in a folder-mapped dictionary, such as custom types
+
+```yaml
+  - path: "./input/dictionary/types/type.yaml.template"
+    mergeFor:
+      items: specifications.dictionaries.types
+      output: "./input/dictionary/types/{{item.name}}.yaml"
+```
+
+In the template, you can access:
+- `{{item.name}}` - the filename (without .yaml extension)
+- `{{item.content}}` - the full content of the YAML file
+
+### Generating Multiple Output files from a Dictionary (mergeFrom)
+
+The `mergeFrom` directive allows you to generate multiple files from a dictionary, such as a folder of YAML files loaded as a dictionary. Each iteration provides an `item` with `name` (the key) and `content` (the value).
+
+Example:
+```yaml
+  - path: "./input/dictionary/types/type.yaml.template"
+    mergeFrom:
+      items: specifications.dictionaries.types
+      output: "./input/dictionary/types/{{item.name}}.yaml"
+```
+In the template, you can access:
+- `{{item.name}}` - the filename (without .yaml extension)
+- `{{item.content}}` - the full content of the YAML file
+
+This is different from `mergeFor`, which is used for iterating over lists. Use `mergeFrom` when your data is a dictionary and you want to generate a file for each key-value pair.
+
 # Contributing
 
 ## Prerequisites

--- a/test/repo/.stage0_template/process.yaml
+++ b/test/repo/.stage0_template/process.yaml
@@ -43,4 +43,8 @@ templates:
     mergeFor: 
       items: service.data.sources
       output: "./{{name}}Service.ts"
+  - path: "./dict-test.j2"
+    mergeFrom:
+      items: specifications.dataDictionary.primary_document_types
+      output: "./{{item.name}}Type.txt"
 

--- a/test/repo/.stage0_template/test_expected/organizationType.txt
+++ b/test/repo/.stage0_template/test_expected/organizationType.txt
@@ -1,0 +1,2 @@
+Type: organization
+Content: {'description': 'A organization of users', 'schema': '$ref:./dataDefinitions/dd.organization.yaml'} 

--- a/test/repo/.stage0_template/test_expected/searchType.txt
+++ b/test/repo/.stage0_template/test_expected/searchType.txt
@@ -1,0 +1,2 @@
+Type: search
+Content: {'description': 'A polymorphic search index', 'ddType': '$ref:./dataDefinitions/dd.search.yaml'} 

--- a/test/repo/.stage0_template/test_expected/userType.txt
+++ b/test/repo/.stage0_template/test_expected/userType.txt
@@ -1,0 +1,2 @@
+Type: user
+Content: {'description': 'A user of {{product}} including employees and customers', 'schema': '$ref:./dataDefinitions/dd.user.yaml'} 

--- a/test/repo/.stage0_template/test_expected/work-orderType.txt
+++ b/test/repo/.stage0_template/test_expected/work-orderType.txt
@@ -1,0 +1,2 @@
+Type: work-order
+Content: {'description': 'A work order to complete some task', 'ddType': '$ref:./dataDefinitions/dd.work-order.yaml'} 

--- a/test/repo/dict-test.j2
+++ b/test/repo/dict-test.j2
@@ -1,0 +1,2 @@
+Type: {{item.name}}
+Content: {{item.content}} 


### PR DESCRIPTION
- Add new mergeFrom directive to handle dictionary iteration alongside existing mergeFor
- Implement dictionary to name/content pair conversion for template context
- Add comprehensive test coverage with dict-test.j2 template
- Update README with documentation and examples for mergeFrom
- Add debug logging and error handling for troubleshooting
- Ensure backward compatibility with existing mergeFor functionality

The mergeFrom directive allows templates to iterate over dictionaries (such as folder-mapped YAML files) and generate a file for each key-value pair, with item.name and item.content available in templates.

Resolves the need for dictionary iteration in template processing while maintaining clean separation from list-based mergeFor.